### PR TITLE
ffmpeg: refine ffmpeg installation instructions

### DIFF
--- a/_presentations/ffmpeg.html
+++ b/_presentations/ffmpeg.html
@@ -95,16 +95,14 @@ General advice on installation from Reto Kromer: [ffmpeg cookbook](https://avpre
 
 `brew tap avpres/formulae`
 
-`brew install --with-openjpeg --with-x265 --with-rubberband --with-svt-av1 --with-tesseract avpres/formulae/ffmpeg`
+`brew install --with-openjpeg --with-rubberband --with-tesseract avpres/formulae/ffmpeg`
 
 #### What does this mean? 
 
 These flags, used during install, allow for...
 
-- *openjpg* include JPEG2000 encoding/decoding
-- *x265* include H.265(HEVC) encoding
+- *openjpeg* include JPEG2000 encoding/decoding
 - *rubberband* include audio filtering
-- *svt-av1* include Scalable Video Technology for AV1 (SVT-AV1 encoder and decoder)
 - *tesseract* include optical character recognition (OCR)
 
 ---


### PR DESCRIPTION
`x265` and `svt-av1` support are now enabled by default.